### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "cubewebsites/magento2-language-en-gb",
     "description": "Magento2 British Language Pack (en_GB)",
-    "version": "100.2.0",
+    "version": "100.3.0",
     "type": "magento2-language",
     "homepage": "https://cubewebsites.com",
     "keywords": [


### PR DESCRIPTION
Needs upgrading for Magento 2.3 (version ID altered as update will error out. This extension is also difficult to remove from the system as it doesn't show on enabled modules and cannot be removed in the conventional way. 