### PR TITLE
Add compatibility with Magento 2.2 & 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "magento/framework": "100.*"
+        "magento/framework": "100.*|101.*|102.*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Currently latest version of the language pack doesn't support Magento 2.2 & 2.3.
This PR fixes this issue via updating composer dependency.